### PR TITLE
Add IOxidation interface to base to allow non-generic handling

### DIFF
--- a/RustFlakes/IOxidation.cs
+++ b/RustFlakes/IOxidation.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2013- Jeremiah Peschka
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace RustFlakes
+{
+    /// <summary>
+    ///     A contract for oxidation implementations.
+    /// </summary>
+    public interface IOxidation
+    {
+        object Oxidize();
+    }
+}

--- a/RustFlakes/Oxidation.cs
+++ b/RustFlakes/Oxidation.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace RustFlakes
 {
-    public abstract class Oxidation<T>
+    public abstract class Oxidation<T> : IOxidation
     {
         public static readonly DateTime DefaultEpoch = new DateTime(2013, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -36,6 +36,11 @@ namespace RustFlakes
 
         public abstract T Oxidize();
 
+        object IOxidation.Oxidize()
+        {
+            return Oxidize();
+        }
+
         protected void Update()
         {
             var timeInMs = CurrentTime();
@@ -51,5 +56,7 @@ namespace RustFlakes
         {
             return (ulong) (DateTime.UtcNow - Epoch).TotalMilliseconds;
         }
+
+
     }
 }

--- a/RustFlakes/RustFlakes.csproj
+++ b/RustFlakes/RustFlakes.csproj
@@ -41,6 +41,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="BigIntegerOxidation.cs" />
     <Compile Include="DecimalOxidation.cs" />
+    <Compile Include="IOxidation.cs" />
     <Compile Include="Oxidation.cs" />
     <Compile Include="SqlServerBigIntOxidation.cs" />
     <Compile Include="UInt64Oxidation.cs" />


### PR DESCRIPTION
I'm creating an identity generator in NHibernate based on Rustflakes. I'm in a position where I would like to be able to work with Oxidizer orthogonally, requiring a non-generic base or interface so I can ignore the generic implementation.
