### PR TITLE
Adding slow oxidation to UInt64Oxidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test-results
 packages/*
 testresults
 *.pfx
+.vs/

--- a/RustFlakes.sln
+++ b/RustFlakes.sln
@@ -1,13 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustFlakes", "RustFlakes\RustFlakes.csproj", "{FACF887B-5810-4771-8991-8623C896C737}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RustFlakes", "RustFlakes\RustFlakes.csproj", "{FACF887B-5810-4771-8991-8623C896C737}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleFlakes", "ConsoleFlakes\ConsoleFlakes.csproj", "{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleFlakes", "ConsoleFlakes\ConsoleFlakes.csproj", "{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustFlakesTests", "RustFlakesTests\RustFlakesTests.csproj", "{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RustFlakesTests", "RustFlakesTests\RustFlakesTests.csproj", "{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,45 +17,48 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FACF887B-5810-4771-8991-8623C896C737}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FACF887B-5810-4771-8991-8623C896C737}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x64.ActiveCfg = Debug|x64
-		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x64.Build.0 = Debug|x64
-		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x86.ActiveCfg = Debug|x86
-		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x86.Build.0 = Debug|x86
+		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x64.Build.0 = Debug|Any CPU
+		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FACF887B-5810-4771-8991-8623C896C737}.Debug|x86.Build.0 = Debug|Any CPU
 		{FACF887B-5810-4771-8991-8623C896C737}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FACF887B-5810-4771-8991-8623C896C737}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FACF887B-5810-4771-8991-8623C896C737}.Release|x64.ActiveCfg = Release|x64
-		{FACF887B-5810-4771-8991-8623C896C737}.Release|x64.Build.0 = Release|x64
-		{FACF887B-5810-4771-8991-8623C896C737}.Release|x86.ActiveCfg = Release|x86
-		{FACF887B-5810-4771-8991-8623C896C737}.Release|x86.Build.0 = Release|x86
+		{FACF887B-5810-4771-8991-8623C896C737}.Release|x64.ActiveCfg = Release|Any CPU
+		{FACF887B-5810-4771-8991-8623C896C737}.Release|x64.Build.0 = Release|Any CPU
+		{FACF887B-5810-4771-8991-8623C896C737}.Release|x86.ActiveCfg = Release|Any CPU
+		{FACF887B-5810-4771-8991-8623C896C737}.Release|x86.Build.0 = Release|Any CPU
 		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x64.ActiveCfg = Debug|x64
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x64.Build.0 = Debug|x64
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x86.ActiveCfg = Debug|x86
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x86.Build.0 = Debug|x86
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x64.Build.0 = Debug|Any CPU
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Debug|x86.Build.0 = Debug|Any CPU
 		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|Any CPU.Build.0 = Release|Any CPU
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x64.ActiveCfg = Release|x64
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x64.Build.0 = Release|x64
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x86.ActiveCfg = Release|x86
-		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x86.Build.0 = Release|x86
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x64.ActiveCfg = Release|Any CPU
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x64.Build.0 = Release|Any CPU
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x86.ActiveCfg = Release|Any CPU
+		{22E33470-6AFE-4DD2-B8B7-B64DE4CB6165}.Release|x86.Build.0 = Release|Any CPU
 		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x64.ActiveCfg = Debug|x64
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x64.Build.0 = Debug|x64
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x86.ActiveCfg = Debug|x86
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x86.Build.0 = Debug|x86
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x64.Build.0 = Debug|Any CPU
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Debug|x86.Build.0 = Debug|Any CPU
 		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|Any CPU.Build.0 = Release|Any CPU
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x64.ActiveCfg = Release|x64
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x64.Build.0 = Release|x64
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x86.ActiveCfg = Release|x86
-		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x86.Build.0 = Release|x86
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x64.ActiveCfg = Release|Any CPU
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x64.Build.0 = Release|Any CPU
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x86.ActiveCfg = Release|Any CPU
+		{08D9E8C2-7228-453F-8BCE-F32AAEFF8725}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8976B142-D2FA-48A3-BB6C-A944791AFD68}
 	EndGlobalSection
 EndGlobal

--- a/RustFlakes/BigIntegerOxidation.cs
+++ b/RustFlakes/BigIntegerOxidation.cs
@@ -95,7 +95,7 @@ namespace RustFlakes
 
             // next 8 bytes are the time counter
             for (var i = 0; i < 8; i++)
-                result[i + 8] = (byte) (LastOxidizedInMs >> (i*8));
+                result[i + 8] = (byte) (LastOxidized >> (i*8));
 
             return new BigInteger(result);
         }

--- a/RustFlakes/DecimalOxidation.cs
+++ b/RustFlakes/DecimalOxidation.cs
@@ -56,8 +56,8 @@ namespace RustFlakes
 
             return new decimal(
                 (int) ((_identifier << 16) + Counter),
-                (int) ((LastOxidizedInMs << 16) + (_identifier >> 16)),
-                (int) ((LastOxidizedInMs >> 16) & 0xFFFFFFFF),
+                (int) ((LastOxidized << 16) + (_identifier >> 16)),
+                (int) ((LastOxidized >> 16) & 0xFFFFFFFF),
                 false,
                 0);
         }

--- a/RustFlakes/Oxidation.cs
+++ b/RustFlakes/Oxidation.cs
@@ -25,31 +25,44 @@ namespace RustFlakes
 
         protected ushort Counter;
         protected readonly DateTime Epoch;
-        protected ulong LastOxidizedInMs;
+        protected ulong LastOxidized;
+        protected ushort OxidationIntervalInMs;
 
         protected Oxidation(DateTime epoch)
         {
             Counter = 0;
             Epoch = epoch;
-            LastOxidizedInMs = CurrentTime();
+            OxidationIntervalInMs = 1;
+            LastOxidized = CurrentTime();
+        }
+
+        protected Oxidation(DateTime epoch, ushort oxidationIntervalInMs)
+        {
+            if (oxidationIntervalInMs == 0)
+                throw new ArgumentOutOfRangeException(nameof(oxidationIntervalInMs), "The oxidation interval must be at least 1 ms.");
+
+            Counter = 0;
+            Epoch = epoch;
+            OxidationIntervalInMs = oxidationIntervalInMs;
+            LastOxidized = CurrentTime();
         }
 
         public abstract T Oxidize();
 
         protected void Update()
         {
-            var timeInMs = CurrentTime();
+            var time = CurrentTime();
 
-            if (LastOxidizedInMs > timeInMs)
+            if (LastOxidized > time)
                 throw new ApplicationException("Clock is running backwards");
 
-            Counter = (ushort) ((LastOxidizedInMs < timeInMs) ? 0 : Counter + 1);
-            LastOxidizedInMs = timeInMs;
+            Counter = (ushort) ((LastOxidized < time) ? 0 : Counter + 1);
+            LastOxidized = time;
         }
 
         private ulong CurrentTime()
         {
-            return (ulong) (DateTime.UtcNow - Epoch).TotalMilliseconds;
+            return (ulong) ((DateTime.UtcNow - Epoch).TotalMilliseconds / OxidationIntervalInMs);
         }
     }
 }

--- a/RustFlakes/SqlServerBigIntOxidation.cs
+++ b/RustFlakes/SqlServerBigIntOxidation.cs
@@ -12,7 +12,15 @@ namespace RustFlakes
         {
         }
 
+        public SqlServerBigIntOxidation(ushort identifier, ushort oxidationIntervalInMs) : base(identifier, oxidationIntervalInMs)
+        {
+        }
+
         public SqlServerBigIntOxidation(ushort identifier, DateTime epoch) : base(identifier, epoch)
+        {
+        }
+
+        public SqlServerBigIntOxidation(ushort identifier, DateTime epoch, ushort oxidationIntervalInMs) : base(identifier, epoch, oxidationIntervalInMs)
         {
         }
 

--- a/RustFlakes/UInt64Oxidation.cs
+++ b/RustFlakes/UInt64Oxidation.cs
@@ -28,8 +28,19 @@ namespace RustFlakes
         {
         }
 
+        public UInt64Oxidation(ushort identifier, ushort oxidationIntervalInMs)
+            : this(identifier, new DateTime(2013, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), oxidationIntervalInMs)
+        {
+        }
+
         public UInt64Oxidation(ushort identifier, DateTime epoch)
             : base(epoch)
+        {
+            _identifier = identifier;
+        }
+
+        public UInt64Oxidation(ushort identifier, DateTime epoch, ushort oxidationIntervalInMs)
+            : base(epoch, oxidationIntervalInMs)
         {
             _identifier = identifier;
         }
@@ -37,7 +48,7 @@ namespace RustFlakes
         public override ulong Oxidize()
         {
             Update();
-            return (LastOxidizedInMs << 32) + (ulong) (_identifier << 16) + Counter;
+            return (LastOxidized << 32) + (ulong) (_identifier << 16) + Counter;
         }
     }
 }

--- a/RustFlakesTests/UInt64OxidationTests.cs
+++ b/RustFlakesTests/UInt64OxidationTests.cs
@@ -17,6 +17,7 @@
 
 using NUnit.Framework;
 using RustFlakes;
+using System.Threading;
 
 namespace RustFlakesTests
 {
@@ -56,6 +57,65 @@ namespace RustFlakesTests
             var key5 = oxidation.Oxidize();
 
             Assert.IsTrue(key5 > key4 && key4 > key3 && key3 > key2 && key2 > key);
+        }
+
+        [Test]
+        public void InDefaultOxidationShouldNotMaintain32BitTimestamp()
+        {
+            var oxidation = new UInt64Oxidation(WorkerId);
+
+            var key1 = oxidation.Oxidize();
+            Thread.Sleep(10);
+            var key2 = oxidation.Oxidize();
+            Thread.Sleep(10);
+            var key3 = oxidation.Oxidize();
+            Thread.Sleep(10);
+
+            var timestamp1 = (uint)(key1 >> 32);
+            var timestamp2 = (uint)(key2 >> 32);
+            var timestamp3 = (uint)(key3 >> 32);
+
+            Assert.IsTrue((timestamp1 != timestamp2) && (timestamp2 != timestamp3));
+        }
+
+        [Test]
+        public void InSlowOxidationShouldMaintain32BitTimestamp()
+        {
+            ushort intervalInMs = 1000; // 1 second
+            var oxidation = new UInt64Oxidation(WorkerId, intervalInMs);
+            
+            var key1 = oxidation.Oxidize();
+            Thread.Sleep(10);
+            var key2 = oxidation.Oxidize();
+            Thread.Sleep(10); 
+            var key3 = oxidation.Oxidize();
+            Thread.Sleep(10);
+
+            var timestamp1 = (uint)(key1 >> 32);
+            var timestamp2 = (uint)(key2 >> 32);
+            var timestamp3 = (uint)(key3 >> 32);
+
+            Assert.IsTrue((timestamp1 == timestamp2) || (timestamp2 == timestamp3));
+        }
+
+        [Test]
+        public void InSlowOxidationShouldNotMaintain32BitTimestamp()
+        {
+            ushort intervalInMs = 1000; // 1 second
+            var oxidation = new UInt64Oxidation(WorkerId, intervalInMs);
+
+            var key1 = oxidation.Oxidize();
+            Thread.Sleep(1000);
+            var key2 = oxidation.Oxidize();
+            Thread.Sleep(1000);
+            var key3 = oxidation.Oxidize();
+            Thread.Sleep(1000);
+
+            var timestamp1 = (uint)(key1 >> 32);
+            var timestamp2 = (uint)(key2 >> 32);
+            var timestamp3 = (uint)(key3 >> 32);
+
+            Assert.IsTrue((timestamp3 > timestamp2) && (timestamp2 > timestamp1));
         }
     }
 }


### PR DESCRIPTION
In many services it is not necessary to have the capacity to generate 65,536 id's per ms. In my case 65,536 id's per second and microservice is more than enough. I think that we can take advantage of this to extend the life of the timestamp which would be interesting for UInt64 oxidations.